### PR TITLE
Fix: truncate Alexa slot values and synonyms to 140-char limit

### DIFF
--- a/Jellyfin.Plugin.AlexaSkill/Alexa/Catalog/CatalogPayload.cs
+++ b/Jellyfin.Plugin.AlexaSkill/Alexa/Catalog/CatalogPayload.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
+using Jellyfin.Plugin.AlexaSkill.Alexa.Util;
 
 namespace Jellyfin.Plugin.AlexaSkill.Alexa.Catalog;
 
@@ -48,8 +50,8 @@ public class CatalogPayload
                 Id = CatalogValue.FormatId(type, id),
                 Name = new CatalogValueName
                 {
-                    Value = name,
-                    Synonyms = synonyms.Count > 0 ? synonyms : null
+                    Value = SlotValueHelper.Truncate(name),
+                    Synonyms = synonyms.Count > 0 ? synonyms.Select(SlotValueHelper.Truncate).ToList() : null
                 }
             };
 

--- a/Jellyfin.Plugin.AlexaSkill/Alexa/DynamicEntities/DynamicEntityBuilder.cs
+++ b/Jellyfin.Plugin.AlexaSkill/Alexa/DynamicEntities/DynamicEntityBuilder.cs
@@ -392,7 +392,7 @@ public class DynamicEntityBuilder : IDisposable
             values.Add(new LastPlayedSlotValue
             {
                 Id = CatalogValue.FormatId(catalogType, item.Id),
-                DisplayName = item.Name,
+                DisplayName = SlotValueHelper.Truncate(item.Name),
                 SlotTypeName = slotTypeName
             });
 
@@ -528,8 +528,8 @@ public class DynamicEntityBuilder : IDisposable
             Id = CatalogValue.FormatId(catalogType, item.Id),
             Name = new DynamicSlotValueName
             {
-                Value = item.Name,
-                Synonyms = synonyms.Count > 0 ? synonyms : null
+                Value = SlotValueHelper.Truncate(item.Name),
+                Synonyms = synonyms.Count > 0 ? synonyms.Select(SlotValueHelper.Truncate).ToList() : null
             }
         });
 

--- a/Jellyfin.Plugin.AlexaSkill/Alexa/Util/SlotValueHelper.cs
+++ b/Jellyfin.Plugin.AlexaSkill/Alexa/Util/SlotValueHelper.cs
@@ -1,0 +1,32 @@
+#nullable enable
+
+namespace Jellyfin.Plugin.AlexaSkill.Alexa.Util;
+
+/// <summary>
+/// Utility methods for Alexa slot value constraints.
+/// </summary>
+public static class SlotValueHelper
+{
+    /// <summary>
+    /// Alexa hard limit for slot value canonical name and synonym length.
+    /// See: https://developer.amazon.com/en-US/docs/alexa/custom-skills/best-practices-for-skill-card-design.html
+    /// SMAPI rejects values exceeding 140 characters with InvalidResponse.
+    /// </summary>
+    public const int MaxSlotValueLength = 140;
+
+    /// <summary>
+    /// Truncates a slot value to the Alexa maximum length, cutting at the last word boundary when possible.
+    /// </summary>
+    /// <param name="value">The slot value or synonym to truncate.</param>
+    /// <returns>The value unchanged if within limit, or truncated to at most 140 characters.</returns>
+    public static string Truncate(string value)
+    {
+        if (value.Length <= MaxSlotValueLength)
+        {
+            return value;
+        }
+
+        int cutAt = value.LastIndexOf(' ', MaxSlotValueLength - 1);
+        return cutAt > 0 ? value[..cutAt] : value[..MaxSlotValueLength];
+    }
+}


### PR DESCRIPTION
## Problem

Alexa enforces a hard 140-character limit on slot values and synonyms. 
When a Jellyfin library contains items with long artist fields (e.g. 
musicals where the artist is a comma-separated cast list), the plugin 
sends values up to 200+ characters. Alexa rejects the response with 
`InvalidResponse`, terminating **every** skill session immediately — 
the skill becomes completely unusable.

Fixes #6 

## Root Cause

Two code paths construct slot values from raw Jellyfin metadata with no 
length guard:

- `DynamicEntityBuilder.TryAddSlotValue()` — the `Dialog.UpdateDynamicEntities` 
  directive sent at runtime on every new session
- `CatalogPayload.FromItems()` — the SMAPI catalog payload uploaded persistently

Both apply to all entity types (artists, albums, series, audiobooks, songs).

## Fix

Added `SlotValueHelper.Truncate(string)` in `Alexa/Util/` that cuts at the 
last word boundary before 140 chars (hard-cuts at 140 if no space found).  
Applied to the canonical value **and** each generated phonetic synonym in 
both code paths.

## Testing

- Build: `dotnet build --configuration Release` → 0 warnings, 0 errors
